### PR TITLE
Handle bug in Bisq price nodes

### DIFF
--- a/src/domain/price_feed.rs
+++ b/src/domain/price_feed.rs
@@ -140,7 +140,7 @@ impl From<PriceDataRaw> for PriceData {
         Self {
             currency,
             price,
-            timestamp: UNIX_EPOCH + Duration::from_secs(timestamp_sec),
+            timestamp: UNIX_EPOCH + Duration::from_millis(timestamp_sec),
             provider,
         }
     }


### PR DESCRIPTION
Even though the returned field is called "timestampSec" the numbers
appear to be in milliseconds.

Might fix https://github.com/bodymindarts/risq/issues/14
cc @leshik 